### PR TITLE
huffman codec utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 output.txt
 *.pyc
+
+**/log

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -1,7 +1,19 @@
+import logging
 from typing import List, Optional
 
 from dahuffman import load_shakespeare, HuffmanCodec
 from bitstring import Bits
+
+
+log_level = logging.DEBUG
+log_file = 'log/agent3.log'
+
+logger = logging.getLogger('Agent 3')
+logger.setLevel(log_level)
+logger.addHandler(logging.FileHandler(log_file))
+
+def debug(*args):
+    logger.info(' '.join(args))
 
 
 class Huffman:
@@ -13,14 +25,17 @@ class Huffman:
             self.codec = load_shakespeare()
 
     def encode(self, msg: str) -> Bits:
-        print(f'[ Huffman.encode ] msg: {msg}')
         bytes = self.codec.encode(msg)
         bits = Bits(bytes=bytes)
 
+        debug('[ Huffman.encode ]', f'msg: {msg} -> bits: {bits.bin}')
         return bits
 
     def decode(self, bits: Bits) -> str:
-        return self.codec.decode(bits.tobytes())
+        decoded = self.codec.decode(bits.tobytes())
+
+        debug('[ Huffman.decode ]', f'bits: {bits.bin} -> msg: {decoded}')
+        return decoded
 
 
 class Agent:

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -1,8 +1,32 @@
+from typing import List, Optional
+
+from dahuffman import load_shakespeare, HuffmanCodec
+from bitstring import Bits
+
+
+class Huffman:
+
+    def __init__(self, dictionary: Optional[List[str]] = None) -> None:
+        if dictionary is not None:
+            self.codec = HuffmanCodec.from_data(''.join(dictionary))
+        else:
+            self.codec = load_shakespeare()
+
+    def encode(self, msg: str) -> Bits:
+        print(f'[ Huffman.encode ] msg: {msg}')
+        bytes = self.codec.encode(msg)
+        bits = Bits(bytes=bytes)
+
+        return bits
+
+    def decode(self, bits: Bits) -> str:
+        return self.codec.decode(bits.tobytes())
+
+
 class Agent:
     def __init__(self):
         self.stop_card = 51
         self.trash_cards = list(range(32, 51))
-        
 
     def encode(self, message):
         encoded_message = []
@@ -25,3 +49,35 @@ class Agent:
     def get_encoded_message(self, deck):
         deck.index(self.stop_card)
         return deck[deck.index(self.stop_card)+1:]
+
+
+# -----------------------------------------------------------------------------
+#   Unit Tests
+# -----------------------------------------------------------------------------
+
+def test_huffman_codec():
+    # Note: the shakespeare codec doesn't seem to be able to handle punctuations
+    cases = ['group 3', 'magic code']
+
+    huffman = Huffman()
+    for tc in cases:
+        orig = tc
+        encoded = huffman.encode(orig)
+        decoded = huffman.decode(encoded)
+
+        assert type(encoded) == Bits, 'error: encoded message is not of type Bits!'
+        assert orig == decoded, 'error: decoded message is not the same as the original'
+
+    print('PASSED: Huffman codec using pre-traind shakespeare text')
+
+    cases = ['group 3', 'magic code', 'hi!']
+    huffman = Huffman(dictionary=cases)
+    for tc in cases:
+        orig = tc
+        encoded = huffman.encode(orig)
+        decoded = huffman.decode(encoded)
+
+        assert type(encoded) == Bits, 'error: encoded message is not of type Bits!'
+        assert orig == decoded, 'error: decoded message is not the same as the original'
+
+    print('PASSED: Huffman codec using dictionary')


### PR DESCRIPTION
# Description

Added a `Huffman` class for encoding _string to bits_ and conversely _bits to string_.

This PR introduces two new dependencies: [dahuffman][1] and [bitstring][2]. I used `dahuffman` for performing huffman encoding and decoding a huffman encoded message. I used the `Bits` class in`bitstring` to represent bits (e.g. '0010101'), this allows easy conversion between bytes and bits.

Also set up a logger and a `debug` function for logging debugging messages to file `log/agent3.log`.


# Huffman Encoding

> Notes from algo class, in case anyone's interested in learning more about it : )

Given a set C of characters, and a frequency f[c] for each character. We want to encode each character c by a
binary string code(c) (not necessarily of same length) so that

- no codeword is a prefix of another codeword
- the encoding minimizes the length of the coded message: i.e  $\sum_c f\left[c\right] \left|code(c)\right|$

  

Optimal variable length prefix code
(can be less costly than fixed length codes)

- Want prefix-free property so that there is no ambiguity when we decode a string
  Example: 

  if code(a)=0 and code(b)=00, then 00 could be aa or b



**Analysis**

We can transform the mapping of binary string to characters into a **Trie** data structure, in which:

- in an optimal solution, all internal node has 2 leaves
- each leaf represents a character and each character is at a leaf



Intuition of placing characters in leaves:

the higher the frequency the shallower we would it like to be.

$\rightarrow$ to build the tree from bottom up, we select the 2 characters with least frequence first (**greedy coice**), merge them as a single leaf (with frequence equal to the sum of individual frequencey) to reduce the problem size by 1.



**Complexity**

operations performed on elements: EXTRACT-MIN, BUILD, REMOVE, INSERT

so we use a **minimum heap**. And the time complexity is $O(n \log n)$ since:

- while loop runs n times (each iteration reduces the queue size by 1)
- each iteration involves 2 EXTRACT-MIN and an INSERT, which is $3 \log n$ when using a minimum heap



[1]: https://pypi.org/project/dahuffman/
[2]: https://bitstring.readthedocs.io/en/latest/constbitarray.html