### PR TITLE
padd huffman encoded messages

### DIFF
--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -1,4 +1,5 @@
 import logging
+import math
 from typing import List, Optional
 
 from dahuffman import load_shakespeare, HuffmanCodec
@@ -18,16 +19,67 @@ def debug(*args) -> None:
     logger.info(' '.join(args))
 
 
+# -----------------------------------------------------------------------------
+#   Agent Parameters
+# -----------------------------------------------------------------------------
+
+CHUNK_SIZE = 5
+
+
+# -----------------------------------------------------------------------------
+#   Codec
+# -----------------------------------------------------------------------------
+
 class Huffman:
 
     def __init__(
             self,
-            dictionary: Optional[List[str]] = None
+            dictionary: Optional[List[str]] = None,
+            chunk_size: int = CHUNK_SIZE
     ) -> None:
         if dictionary is not None:
             self.codec = HuffmanCodec.from_data(''.join(dictionary))
         else:
             self.codec = load_shakespeare()
+
+        self.chunk_size = chunk_size
+        self.pad_metadata_size = math.ceil(math.log2(chunk_size -1))
+
+    def _add_padding(self, msg: Bits) -> Bits:
+        need_pad_size = self.chunk_size - (len(msg) % self.chunk_size)
+
+        if self.pad_metadata_size > need_pad_size:
+            pad_bits_size = need_pad_size + self.chunk_size - self.pad_metadata_size
+        else:
+            pad_bits_size = need_pad_size - self.pad_metadata_size
+
+        total_pad_size = self.pad_metadata_size + pad_bits_size
+
+        # transform pad_bits_size into binary and add pad_bits_size of 0
+        padding = Bits(uint=pad_bits_size << pad_bits_size, length=total_pad_size)
+        padded_msg_bin = '0b{}{}'.format(padding.bin, msg.bin)
+        padded_msg = Bits(bin=padded_msg_bin)
+
+        debug('[ Huffman._add_padding ]',
+                f'len(msg): {len(msg)}, msg: {msg.bin}',
+                f'chunk size: {self.chunk_size}',
+                f'padding: {padding.bin[:self.pad_metadata_size]}',
+                f'+ {padding.bin[self.pad_metadata_size:]}',
+                f'padded msg: {padded_msg.bin}')
+
+        return padded_msg
+
+    def _remove_padding(self, msg: Bits) -> Bits:
+        pad_bits_size = int(msg.bin[:self.pad_metadata_size], 2)
+        msg_start_idx = self.pad_metadata_size + pad_bits_size
+        original_encoding = Bits(bin=f'0b{msg.bin[msg_start_idx:]}')
+
+        debug('[ Huffman._remove_padding ]',
+                f'padded msg: {msg.bin[:self.pad_metadata_size]}',
+                f'+ {msg.bin[self.pad_metadata_size:msg_start_idx]}',
+                f'+ {msg.bin[msg_start_idx:]}')
+
+        return original_encoding
 
     def encode(
             self,
@@ -35,17 +87,20 @@ class Huffman:
     ) -> Bits:
         bytes = self.codec.encode(msg)
         bits = Bits(bytes=bytes)
-
         debug('[ Huffman.encode ]', f'msg: {msg} -> bits: {bits.bin}')
-        return bits
+
+        padded_bits = self._add_padding(bits)
+
+        return padded_bits
 
     def decode(
             self,
             bits: Bits
     ) -> str:
+        bits = self._remove_padding(bits)
         decoded = self.codec.decode(bits.tobytes())
-
         debug('[ Huffman.decode ]', f'bits: {bits.bin} -> msg: {decoded}')
+
         return decoded
 
 
@@ -123,6 +178,7 @@ def test_huffman_codec():
         assert type(
             encoded) == Bits, 'error: encoded message is not of type Bits!'
         assert orig == decoded, 'error: decoded message is not the same as the original'
+        assert (len(encoded) % CHUNK_SIZE) == 0, f'error: encoded message has size {len(encoded)}, not a multiple of {CHUNK_SIZE}'
 
     print('PASSED: Huffman codec using pre-traind shakespeare text')
 
@@ -135,5 +191,6 @@ def test_huffman_codec():
 
         assert type(encoded) == Bits, 'error: encoded message is not of type Bits!'
         assert orig == decoded, 'error: decoded message is not the same as the original'
+        assert (len(encoded) % CHUNK_SIZE) == 0, f'error: encoded message has size {len(encoded)}, not a multiple of {CHUNK_SIZE}'
 
     print('PASSED: Huffman codec using dictionary')


### PR DESCRIPTION
# Description

Modified `Huffman` such that the encoded message is always a multiple of `CHUNK_SIZE`, added this check in unit tests.