### PR TITLE
fix pad metadata size calculation

### DIFF
--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -43,7 +43,7 @@ class Huffman:
             self.codec = load_shakespeare()
 
         self.chunk_size = chunk_size
-        self.pad_metadata_size = math.ceil(math.log2(chunk_size -1))
+        self.pad_metadata_size = math.ceil(math.log2(chunk_size))
 
     def _add_padding(self, msg: Bits) -> Bits:
         need_pad_size = self.chunk_size - (len(msg) % self.chunk_size)


### PR DESCRIPTION
# Description

Adding a fix for the calculation of pad metadata size.

Assume the pad metadata size is *n* bits. We need to ensure that 2^n - 1 >= k - 1, where k - 1 is the number of paddings other than the metadata we need to insert in the worst case scenario (e.g. metadata size is 2, and we actually just need padding of 1, so we need to insert `CHUNK_SIZE=k` - 1 paddings).

Thus the minimal n is given by the ceil of log_2 n.