### PR TITLE
Metadata as factorial with dictionary shorten

### DIFF
--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -112,8 +112,8 @@ class Agent:
         step_size, parts, start_padding, end_padding = self.get_parts(bit_str)
         
         if step_size == -1:
-            raise Exception("Could not encode message")
-            return list(range(52))
+            # raise Exception("Could not encode message")
+            return list(reversed(range(52)))
 
         chunk_size = [len(part) for part in parts]
         cards = [int(part, 2) for part in parts]
@@ -150,10 +150,14 @@ class Agent:
             self,
             deck
     ) -> str:
+        if deck == list(reversed(range(52))):
+            return "Could not encode message"
+
 
         deck = self.remove_trash_cards(deck)
         encoded_message = self.get_encoded_message(deck)
         useless_cards = self.get_useless_cards(deck)
+
         if len(encoded_message) == 0:
             return "NULL"
 
@@ -166,9 +170,6 @@ class Agent:
         start_padding = int(start_padding, 2)
         end_padding = int(end_padding, 2)
 
-        print("Decoded to")
-        print(step_size, start_padding, end_padding, lengths)
-
         if step_size == 0:
             # no linear probing
             cards = encoded_message
@@ -180,7 +181,8 @@ class Agent:
         chunk_sizes = [self.max_chunk_size if length == '0' else self.max_chunk_size-1 for length in lengths]
         bit_str = ''.join(['{0:b}'.format(card).zfill(chunk_sizes[i]) for i, card in enumerate(cards)])
 
-        bit_str = bit_str[start_padding:-end_padding]
+        bit_str = bit_str[start_padding:-end_padding] if end_padding > 0 else bit_str[start_padding:]
+
 
         decoded_message = self.huff.decode(Bits(bin=bit_str), padding_len=0)
 
@@ -250,6 +252,7 @@ class Agent:
 
     def un_hash_msg(self, encoded_msg, step_size):
         # attempt to unhash the encoded message
+        step_size = step_size*2
         encoded_msg_hash_table = {}
 
         message = []
@@ -265,6 +268,7 @@ class Agent:
     def hash_msg_with_linear_probe(self, chunks, step_size):
         #attempt a linear probe at the given step size
         hash_table = {}
+        step_size = step_size*2
 
         encoded_msg = []
         for chunk in chunks:
@@ -343,8 +347,6 @@ class Agent:
         start_padding = metadata[messageLength+2:messageLength+5]
         last_chunk_padding = metadata[messageLength+5:messageLength+8]
         extra_padding = metadata[messageLength+8:]
-        print('metadata', metadata)
-        print('cards', metadataCards)
 
         return step_size, start_padding, last_chunk_padding, lengths
 

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -47,7 +47,7 @@ class PermutationGenerator:
 
         permutation = self._perm_unrank(rank, base)
         if permutation is None:
-            print("trying to create permuation for number ", rank)
+            print(f"trying to create permuation for number {rank} with {len(cards)} cards")
             return cards
 
         return [cards[self.alphabet.index(i)] for i in permutation]
@@ -368,12 +368,12 @@ class Agent:
         Returns a list of cards
         '''
         cards = [str(card) for card in cards]
-        print(step_size, start_padding, end_padding, lengths)
+
         metadata = step_size + start_padding + end_padding + lengths
         
         last_n_cards = cards[-self.n_needed_metadata(2**len(metadata)):]
         permutation = self.permuter.encode(last_n_cards, int(metadata, 2))
-        print(self.n_needed_metadata(int(metadata, 2)))
+
         return [int(card) for card in permutation]
         
     def decode_metadata(self, uselessCards : List[int], messageLength : int):
@@ -391,7 +391,7 @@ class Agent:
         start_padding = int(metadata[2:5], 2)
         end_padding = int(metadata[5:8], 2)
         lengths = metadata[8:8+messageLength]
-        print(step_size, start_padding, end_padding, lengths)
+
         return step_size, start_padding, end_padding, lengths
 
     def n_needed_metadata(self, messageLength : int):

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -12,7 +12,7 @@ import numpy as np
 import math
 from math import factorial as fac
 from itertools import groupby
-
+import requests
 
 log_level = logging.DEBUG
 log_file = 'log/agent3.log'
@@ -178,11 +178,21 @@ class Agent:
         self.permuter = PermutationGenerator()
         self.max_chunk_size = 6
 
+        r = requests.get('https://raw.githubusercontent.com/mwcheng21/minified-text/main/minified.txt')
+        minified_text = r.text
+        self.abrev2word = {}
+        self.word2abrev = {}
+        for line in minified_text.splitlines():
+            [shortened, full] = line.split(' ')
+            self.abrev2word[shortened] = full
+            self.word2abrev[full] = shortened
+
     def encode(
             self,
             msg: str
         ) -> List[int]:
 
+        msg = ' '.join([self.word2abrev[word] if word in self.word2abrev else word for word in msg.split(" ")])
         bit_str = self.huff.encode(msg, padding_len=0).bin
 
         step_size, parts, start_padding, end_padding = self.get_parts(bit_str)
@@ -256,6 +266,8 @@ class Agent:
         bit_str = bit_str[start_padding:-end_padding] if end_padding > 0 else bit_str[start_padding:]
 
         decoded_message = self.huff.decode(Bits(bin=bit_str), padding_len=0)
+
+        decoded_message = ' '.join([self.abrev2word[word] if word in self.abrev2word else word for word in decoded_message.split(" ")])
 
         return decoded_message
 

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -69,7 +69,9 @@ class PermutationGenerator:
         return n
 
     def n_needed(self, messageLength):
-        return self.fact[messageLength]
+        for i in range(100):
+            if messageLength < self.fact[i]:
+                return i
 
     def _perm_rank(self, target, base):
         ''' Determine the permutation rank of string `target`
@@ -366,11 +368,12 @@ class Agent:
         Returns a list of cards
         '''
         cards = [str(card) for card in cards]
-
+        print(step_size, start_padding, end_padding, lengths)
         metadata = step_size + start_padding + end_padding + lengths
-        last_n_cards = cards[-self.n_needed_metadata(len(lengths)):]
+        
+        last_n_cards = cards[-self.n_needed_metadata(2**len(metadata)):]
         permutation = self.permuter.encode(last_n_cards, int(metadata, 2))
-
+        print(self.n_needed_metadata(int(metadata, 2)))
         return [int(card) for card in permutation]
         
     def decode_metadata(self, uselessCards : List[int], messageLength : int):
@@ -380,14 +383,15 @@ class Agent:
         Returns a tuple of step_size, start_padding, end_padding, lengths
         '''
         cards = [str(card) for card in uselessCards]
-        last_n_cards = cards[-self.n_needed_metadata(messageLength):]
+        last_n_cards = cards[-self.n_needed_metadata(2**(messageLength+3+3+2)):]
+
         metadata = self.permuter.decode(last_n_cards)
         metadata = '{0:b}'.format(metadata).zfill(2 + 3 + 3 + messageLength)
         step_size = int(metadata[:2], 2)
         start_padding = int(metadata[2:5], 2)
         end_padding = int(metadata[5:8], 2)
         lengths = metadata[8:8+messageLength]
-
+        print(step_size, start_padding, end_padding, lengths)
         return step_size, start_padding, end_padding, lengths
 
     def n_needed_metadata(self, messageLength : int):

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -178,6 +178,8 @@ class Agent:
         self.permuter = PermutationGenerator()
         self.max_chunk_size = 6
 
+
+        # if can use precomp, comment this out
         r = requests.get('https://raw.githubusercontent.com/mwcheng21/minified-text/main/minified.txt')
         minified_text = r.text
         self.abrev2word = {}
@@ -186,6 +188,15 @@ class Agent:
             [shortened, full] = line.split(' ')
             self.abrev2word[shortened] = full
             self.word2abrev[full] = shortened
+
+        # then uncomment this
+        # with open('minified.txt', 'r') as f:
+        #     self.abrev2word = {}
+        #     self.word2abrev = {}
+        #     for line in f.splitlines():
+        #         [shortened, full] = line.split(' ')
+        #         self.abrev2word[shortened] = full
+        #         self.word2abrev[full] = shortened
 
     def encode(
             self,

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -1,9 +1,11 @@
+import chunk
 import logging
 from typing import List, Optional
 from cards import valid_deck
 
 from dahuffman import load_shakespeare, HuffmanCodec
 from bitstring import Bits
+from importlib.metadata import metadata
 import numpy as np
 
 
@@ -23,7 +25,7 @@ def debug(*args) -> None:
 #   Agent Parameters
 # -----------------------------------------------------------------------------
 
-MAX_CHUNK_SIZE = 5
+MAX_CHUNK_SIZE = 6
 
 # -----------------------------------------------------------------------------
 #   Codec
@@ -36,7 +38,7 @@ class Huffman:
             dictionary: Optional[List[str]] = None
     ) -> None:
         if dictionary is not None:
-            self.codec = HuffmanCodec.from_data(''.join(dictionary))
+            self.codec = HuffmanCodec.from_frequencies(dictionary)
         else:
             self.codec = load_shakespeare()
 
@@ -95,66 +97,109 @@ class Agent:
         self.trash_cards = list(range(self.trash_card_start_idx, 51))
         self.rng = np.random.default_rng(seed=42)
         self.huff = Huffman()  # Create huffman object
-        self.max_chunk_size = MAX_CHUNK_SIZE
+
+        self.max_chunk_size = 6
 
     def encode(
             self,
             msg: str
         ) -> List[int]:
 
+        bit_str = self.huff.encode(msg, padding_len=0).bin
 
-        bit_len = len(self.huff.encode(msg, padding_len=0).bin)
+        step_size, parts, start_padding, end_padding = self.get_parts(bit_str)
+        
+        if step_size == -1:
+            return list(range(52))
 
-        # Use multiple chunk sizes to find the largest chunk size that allows n duplicate chunks
-        for chunk_size in reversed(range(1, self.max_chunk_size + 1)):
-            padding =  (chunk_size - (bit_len % chunk_size)) % chunk_size
+        chunk_size = [len(part) for part in parts]
+        cards = [int(part, 2) for part in parts]
 
-            # Store metadata of chunk size and padding in first card
-            encode_msg = [int('{0:b}'.format(chunk_size).zfill(3) + '{0:b}'.format(padding).zfill(3), 2)]
+        if step_size > 0:
+            cards = self.hash_msg_with_linear_probe(cards, step_size=step_size)
 
-            # Convert Huffman to binary
-            bit_str = self.huff.encode(msg, padding_len=padding).bin
-            
-            # Split binary into chunks -> Convert to string to do this
-            parts = [str(bit_str)[i:i+chunk_size] for i in range(0, len(str(bit_str)), chunk_size)]
+        print(parts)
+        print(cards)
+        print(chunk_size)
+        print(step_size)
 
-            # Convert each chunk to int and add to encode_msg
-            for i in parts:
-                card = int(Bits(bin=i).bin, 2)
-                while card in encode_msg:
-                    card += 2**chunk_size
-                encode_msg.append(card)
+        encode_msg = []
 
-            # Check if encode_msg is valid
-            if max(encode_msg) < self.trash_card_start_idx and len(set(encode_msg)) == len(encode_msg):
+        for i in range(4):
+            possible_card = int('0{0:b}'.format(i).zfill(2) + '{0:b}'.format(end_padding).zfill(3), 2)
+            if possible_card not in cards:
+                encode_msg.append(possible_card)
                 break
+        else: # No card found
+            raise Exception('No card found')
+        
+        encode_msg.extend(cards)
+
+        #TODO: encode 2 bits for step size - is this needed? or can we just try them all - same thing with padding
+        # 3 bits for start padding
+        # 3 bits for end padding
+        # n bits for each chunk size
+        metadata = []
+        lengths = ''.join(["0" if size == self.max_chunk_size else "1" for size in chunk_size])
+        print(lengths)
 
         useless_cards = [card for card in range(0, self.trash_card_start_idx)
                          if card not in encode_msg]
-        deck = self.trash_cards + useless_cards + [self.stop_card] + encode_msg
+        deck = self.trash_cards + useless_cards + metadata + [self.stop_card] + encode_msg
+
+        print("outputs")
+        print(valid_deck(deck))
+        print(sum(deck) - sum(range(52)))
+        print(deck)
 
         return deck if valid_deck(deck) else list(range(52))
     def decode(
             self,
             deck
     ) -> str:
+
+
         deck = self.remove_trash_cards(deck)
         encoded_message = self.get_encoded_message(deck)
 
         if len(encoded_message) == 0:
             return "NULL"
 
-        metadata = '{0:b}'.format(encoded_message[0]).zfill(6)
-        chunk_size, padding = int(metadata[:3], 2), int(metadata[3:], 2)
-        encoded_message = encoded_message[1:]
+        last_chunk_len, last_chunk_padding = int('{0:b}'.format(encoded_message[0]).zfill(6)[3:], 2), int('{0:b}'.format(encoded_message[1]).zfill(6)[3:], 2)
+
+        encoded_message = encoded_message[2:]
 
         bit_str = ''
-        for card in encoded_message:
-            while card >= 2**chunk_size:
-                card -= 2**chunk_size
-            bit_str += '{0:b}'.format(card).zfill(chunk_size)
+        seenBitStr = set()
+        for idx, card in enumerate(encoded_message[:-1]):
+            next_card = encoded_message[idx + 1]
+            #currently assume that the next chunnk is max size, MAY NOT BE TRUE THOUGH!!!
+            next_bits = '{0:b}'.format(next_card).zfill(self.max_chunk_size)
 
-        decoded_message = self.huff.decode(Bits(bin=bit_str), padding_len=padding)
+            normal_chunk = '{0:b}'.format(card).zfill(self.max_chunk_size)
+            naked_card = '{0:b}'.format(card)
+            minus_one_chunk = naked_card.zfill(self.max_chunk_size-1) + next_bits[:1] if len(naked_card) < self.max_chunk_size else naked_card
+
+            real_chunk_size = self.max_chunk_size
+
+            if minus_one_chunk in seenBitStr:
+                real_chunk_size -= 1
+                if normal_chunk not in seenBitStr:
+                    print("s")
+            if normal_chunk in seenBitStr:
+                print("ERROR??")
+            # else:
+            #     real_chunk_size = self.max_chunk_size
+
+            seenBitStr.add('{0:b}'.format(card).zfill(real_chunk_size))
+            bit_str += '{0:b}'.format(card).zfill(real_chunk_size)
+
+        last_bits = '{0:b}'.format(encoded_message[-1])[:-last_chunk_padding].zfill(last_chunk_len) if last_chunk_padding > 0 else '{0:b}'.format(encoded_message[-1]).zfill(last_chunk_len)
+
+        bit_str += last_bits
+
+        print(bit_str)
+        decoded_message = self.huff.decode(Bits(bin=bit_str), padding_len=0)
 
         return decoded_message
 
@@ -173,6 +218,88 @@ class Agent:
         deck.index(self.stop_card)
         return deck[deck.index(self.stop_card)+1:]
 
+    def get_parts(self, bit_str):
+        '''
+        Takes in a bit string 
+
+        Returns a tuple of is_able_to_encode, parts, start_padding, end_padding, contains_no_duplicates
+        '''
+        chunk_size = self.max_chunk_size
+        padding = max(chunk_size, ((chunk_size - len(bit_str) % chunk_size) % chunk_size))
+        last_card_padding = 0
+    
+        for i in range(padding):
+            start_padding = i
+
+            padded_bit_str = '0' * start_padding + bit_str
+            parts = []
+            while len(padded_bit_str) > 0 and chunk_size <= len(padded_bit_str):
+                if padded_bit_str[:chunk_size][0] == '0':
+                    parts.append(padded_bit_str[:chunk_size])
+                    padded_bit_str = padded_bit_str[chunk_size:]
+                else:
+                    parts.append(padded_bit_str[:chunk_size-1])
+                    padded_bit_str = padded_bit_str[chunk_size-1:]
+
+            if len(padded_bit_str) > 0:
+                last_card_padding = chunk_size - len(padded_bit_str)
+                potential_card = padded_bit_str + '0' * last_card_padding
+                if potential_card in parts or potential_card[0] == '1':
+                    last_card_padding -= 1
+                    potential_card = padded_bit_str + '0' * last_card_padding
+                parts.append(potential_card)
+
+            int_deck = [int(part, 2) for part in parts]
+            if len(int_deck) == len(set(int_deck)):
+                # no duplicates
+                return 0, parts, start_padding, last_card_padding
+
+            # must be duplicates, so check if can hash
+            canHash, step_size = self.can_hash_msg(int_deck)
+            if canHash:
+                break
+        else:
+            return -1, None, None, None
+        
+        return step_size, parts, start_padding, last_card_padding
+
+    def un_hash_msg(self, encoded_msg, step_size):
+        # attempt to unhash the encoded message
+        encoded_msg_hash_table = {}
+
+        message = []
+        for i, card in enumerate(encoded_msg):
+            address_of_card = card
+            while address_of_card - step_size in encoded_msg_hash_table:
+                address_of_card -= step_size
+
+            encoded_msg_hash_table[address_of_card] = card
+            message.append(address_of_card)
+        return message
+
+    def hash_msg_with_linear_probe(self, chunks, step_size):
+        #attempt a linear probe at the given step size
+        hash_table = {}
+
+        encoded_msg = []
+        for chunk in chunks:
+            address_of_chunk = chunk
+            while address_of_chunk in hash_table:
+                address_of_chunk += step_size
+            hash_table[address_of_chunk] = chunk
+            encoded_msg.append(address_of_chunk)
+        return encoded_msg
+
+    def can_hash_msg(
+            self,
+            chunks
+    ) -> bool:
+        for i in range(1, 5):
+            encoded_msg = self.hash_msg_with_linear_probe(chunks, i)
+            decoded_hash = self.un_hash_msg(encoded_msg, i)
+            if decoded_hash == chunks:
+                return True, i
+        return False, None
 
 # -----------------------------------------------------------------------------
 #   Unit Tests

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -39,7 +39,8 @@ class PermutationGenerator:
         ''' Encode the given cards into a permutation of the given rank '''
         base = ''.join(list([str(num) for num in range(len(cards))]))
         permutation = self._perm_unrank(rank, base)
-
+        if permutation is None:
+            print("trying to create permuation for number ", rank)
         return [cards[int(i)] for i in permutation]
 
     def decode(self, cards):
@@ -354,7 +355,7 @@ class Agent:
         cards = [str(card) for card in cards]
 
         metadata = step_size + start_padding + end_padding + lengths
-
+        print("length of message ", len(lengths))
         last_5_cards = cards[-9:]
         permutation = self.permuter.encode(last_5_cards, int(metadata, 2))
 

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -1,15 +1,11 @@
-import chunk
 from concurrent.futures import thread
-from curses import meta
 import logging
 from typing import List, Optional
 from cards import valid_deck
 
 from dahuffman import load_shakespeare, HuffmanCodec
 from bitstring import Bits
-from importlib.metadata import metadata
 import numpy as np
-import math
 from math import factorial as fac
 from itertools import groupby
 import requests

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -145,7 +145,9 @@ class Agent:
 
         deck = self.trash_cards + useless_cards + metadata_cards + [self.stop_card] + encode_msg
 
+        print(end_padding, start_padding, step_size, lengths)
         return deck if valid_deck(deck) else list(range(52))
+
     def decode(
             self,
             deck
@@ -166,10 +168,6 @@ class Agent:
         # decode metadata
         step_size, start_padding, end_padding, lengths = self.decode_metadata(useless_cards, messageLength)
 
-        step_size = int(step_size, 2)
-        start_padding = int(start_padding, 2)
-        end_padding = int(end_padding, 2)
-
         if step_size == 0:
             # no linear probing
             cards = encoded_message
@@ -182,7 +180,6 @@ class Agent:
         bit_str = ''.join(['{0:b}'.format(card).zfill(chunk_sizes[i]) for i, card in enumerate(cards)])
 
         bit_str = bit_str[start_padding:-end_padding] if end_padding > 0 else bit_str[start_padding:]
-
 
         decoded_message = self.huff.decode(Bits(bin=bit_str), padding_len=0)
 
@@ -252,7 +249,7 @@ class Agent:
 
     def un_hash_msg(self, encoded_msg, step_size):
         # attempt to unhash the encoded message
-        step_size = step_size*2
+        step_size = step_size if step_size != 3 else 5
         encoded_msg_hash_table = {}
 
         message = []
@@ -268,7 +265,7 @@ class Agent:
     def hash_msg_with_linear_probe(self, chunks, step_size):
         #attempt a linear probe at the given step size
         hash_table = {}
-        step_size = step_size*2
+        step_size = step_size if step_size != 3 else 5
 
         encoded_msg = []
         for chunk in chunks:
@@ -283,7 +280,7 @@ class Agent:
             self,
             chunks
     ) -> bool:
-        for i in range(1, 5):
+        for i in range(1, 4):
             encoded_msg = self.hash_msg_with_linear_probe(chunks, i)
             decoded_hash = self.un_hash_msg(encoded_msg, i)
             if decoded_hash == chunks:
@@ -348,7 +345,7 @@ class Agent:
         last_chunk_padding = metadata[messageLength+5:messageLength+8]
         extra_padding = metadata[messageLength+8:]
 
-        return step_size, start_padding, last_chunk_padding, lengths
+        return int(step_size, 2), int(start_padding, 2), int(last_chunk_padding, 2), lengths
 
 
 # -----------------------------------------------------------------------------

--- a/messages/agent3/default.txt
+++ b/messages/agent3/default.txt
@@ -1,6 +1,23 @@
-space word
 123456
 ALLCAPS
+;',./
+1:22
+$68
+expensive :)!
+@someone
 aabbcc
 aaaaaaaaa
 aaaaabbbb
+dermatoglyphics are fun
+dermatoglyphics dermatoglyphics
+unreproducible
+reinforcement incoming
+battalion flank
+spy in our midst
+enemy has fallen
+---
+dermatoGLYphics
+asdfghjklqwertz
+agagag
+70 degrees
+pramn

--- a/messages/agent3/default.txt
+++ b/messages/agent3/default.txt
@@ -1,0 +1,6 @@
+space word
+123456
+ALLCAPS
+aabbcc
+aaaaaaaaa
+aaaaabbbb


### PR DESCRIPTION
Requires import requests

Workflow updates:
message to shortened message
shortened message to bitstring with huffman encoding
bitstring to chunks, where collisions resolve through linear probing
chunks to cards
store metadata using factorial (to avoid duplicates)



