### PR TITLE
partial match

### DIFF
--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -808,7 +808,7 @@ class PermutationConverter(BDC):
 
     def to_deck(self, bits: Bits) -> Optional[tuple[Deck, Deck]]:
         # optimization: truncate trailing zeros in bits
-        _bits = Bits(bin=bits.bin.rstrip('0'))
+        _bits = Bits(bin=bits.bin.rstrip('0') or '0')
         bit_len = len(_bits.bin)
         if bit_len < len(bits.bin):
             info(f"{self.__str__()} optimiation: truncating",

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -807,7 +807,12 @@ class PermutationConverter(BDC):
         self.permuter = PermutationGenerator()
 
     def to_deck(self, bits: Bits) -> Optional[tuple[Deck, Deck]]:
-        bit_len = len(bits.bin)
+        # optimization: truncate trailing zeros in bits
+        _bits = Bits(bin=bits.bin.rstrip('0'))
+        bit_len = len(_bits.bin)
+        if bit_len < len(bits.bin):
+            info(f"{self.__str__()} optimiation: truncating",
+            f"{len(bits.bin) - bit_len} trailing zeros, new bit len: {bit_len}")
 
         num_msg_cards = self.permuter.n_needed(2 ** bit_len)
         num_metdata_cards = 6 # 6! = 720, can handle bit length up to 720
@@ -823,7 +828,7 @@ class PermutationConverter(BDC):
 
         msg = [
             int(card)
-            for card in self.permuter.encode(msg_cards, bits.uint)
+            for card in self.permuter.encode(msg_cards, _bits.uint)
         ]
         msg_metadata = [
             int(card)


### PR DESCRIPTION
# Description

With partial match implemented, we score **22/23** for _messages/agent3/default.txt_ and outputting a partial match `dermatoGLYphic*` for `dermatoGLYphics`.


Three **important changes**:

- `MetadataCodec`
  - adds 1 bit indicating partial match to the metadata, now 5 -> 6 bits
  - a 6 bit metadata can no longer be encoded with a single card, I used a hack to encode it with 2 cards from 0 - 31 s.t. they are guaranteed to be unique (took me a while to figure this out 😣)
- `Agent.encode`
  - if encoding the entire original message fails, will do partial matching using a bit pattern of 79 bits that are guaranteed to succeed
  - TODOs
    - e.g. using binary search to find dynamically the longest prefix we can encode
    - should we truncate bits or the message, currently it's done on bits and seem to work fine
- `Agent.decode`
  - if the metadata tells us that it's a partial match, we append `*` to the decoded message

Two **optimizations**:

- `to_partial_deck` now runs all BDC converters and use the partial deck that uses the fewest number of cards
- `PermutationConverter`, the rank of a bit pattern `10100` is the same as `101`, so we can safely strip the rightmost zeros during encoding to save bits.