### PR TITLE
assertions to detect null deck

### DIFF
--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -45,6 +45,7 @@ if isfile(log_file):
 #   Agent Parameters
 # -----------------------------------------------------------------------------
 
+MAX_PERMUTATION_N = 31
 MAX_CHUNK_SIZE = 6
 
 
@@ -55,7 +56,8 @@ class PermutationGenerator:
         self.alphabet = '0123456789abcdefghijklmnopqrstuvwxyz'
         self.fact = [0] * 34
         self.fact[0] = 1
-        for i in range(1, 32):
+        self.max_fact_n = 31
+        for i in range(1, self.max_fact_n + 1):
             self.fact[i] = (self.fact[i - 1] * i)
 
     def _perm_count(self, s: str) -> int:
@@ -130,6 +132,10 @@ class PermutationGenerator:
         for i in range(100):
             if rank < self.fact[i]:
                 return i
+        else:
+            # return a really large n to indicate to the caller that
+            # encoding the rank using permutation won't work
+            return sys.maxsize
 
 
 # -----------------------------------------------------------------------------

--- a/agents/agent3.py
+++ b/agents/agent3.py
@@ -807,7 +807,12 @@ class PermutationConverter(BDC):
         self.permuter = PermutationGenerator()
 
     def to_deck(self, bits: Bits) -> Optional[tuple[Deck, Deck]]:
-        bit_len = len(bits.bin)
+        # optimization: truncate trailing zeros in bits
+        _bits = Bits(bin=bits.bin.rstrip('0'))
+        bit_len = len(_bits.bin)
+        if bit_len < len(bits.bin):
+            info(f"{self.__str__()} optimiation: truncating",
+            f"{len(bits.bin) - bit_len} trailing zeros, new bit len: {bit_len}")
 
         num_msg_cards = self.permuter.n_needed(2 ** bit_len)
         num_metdata_cards = 6 # 6! = 720, can handle bit length up to 720
@@ -823,7 +828,7 @@ class PermutationConverter(BDC):
 
         msg = [
             int(card)
-            for card in self.permuter.encode(msg_cards, bits.uint)
+            for card in self.permuter.encode(msg_cards, _bits.uint)
         ]
         msg_metadata = [
             int(card)


### PR DESCRIPTION
# Description

(depends on #16)
Created a framework for handling decks that don't contain messages or are shuffled too many times. Specifically, I

- created a customized exception `NullDeckException` for indicating decks with the above properties and a helper method `agent_assert` to easily make assertions in different parts of the code
- used a `try ... except` block wrapping decoding steps in `Agent.decode` that catches uncaught runtime exceptions/errors and explicit NullDeckExceptions

This now allows us to detect null decks in a distributed fashion, by using `agent_assert` or directly raising `NullDeckException` in different places to indicate null decks. I've implemented a couple, most importantly in `MetadataCodec.decode` and `Agent._untangle`.

# How has this been tested?

The score of our agent on non-null decks are not impacted, still 22/23 for:

```shell
$ python3 main.py -a 3 -n 19 -m messages/agent3/default.txt -o log/output_agent3.txt -v
```

We achieve a score of **2829/2922**  (accuracy: 96.8%) when we use a null rate of 0.99:

```shell
$ python3 main.py -a 3 -n 19 -m messages/agent3/default.txt -o log/output_agent3.txt -v -nr 0.99
```